### PR TITLE
Return an error tuple when a non-JSON response is received

### DIFF
--- a/lib/geoip/lookup.ex
+++ b/lib/geoip/lookup.ex
@@ -53,7 +53,10 @@ defmodule GeoIP.Lookup do
   defp put_in_cache(result, _), do: result
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
-    {:ok, Jason.decode!(body, keys: :atoms)}
+    case Jason.decode(body, keys: :atoms) do
+      {:ok, json} -> {:ok, json}
+      {:error, error} -> {:error, %Error{reason: error}}
+    end
   end
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: _, body: body}}) do

--- a/test/geoip_test.exs
+++ b/test/geoip_test.exs
@@ -180,6 +180,17 @@ defmodule GeoIPTest do
         {:error, _} = GeoIP.lookup("invalidhost")
       end
     end
+
+    test "returns error when a non-JSON response is received" do
+      for status <- [200, 400, 404, 500] do
+        html = "<html><body>Error!</body>"
+        mock_response = {:ok, %HTTPoison.Response{status_code: status, body: html}}
+
+        with_mock(HTTPoison, get: fn _ -> mock_response end) do
+          {:error, _} = GeoIP.lookup("github.com")
+        end
+      end
+    end
   end
 
   describe "lookup/1 using ipstack" do


### PR DESCRIPTION
First, let me say thanks for publishing such a useful "small, sharp tool" of a library. We've been happily using it in production for awhile now. ☺️

We saw an issue today where our geo IP provider had an outage and was rendering an HTML error page, rather than sending the expected JSON request. With this PR, `GeoIP.lookup/1` will return an error tuple in that case rather than raising an exception.

Stacktrace from the issue we saw:

```
** (Jason.DecodeError) unexpected byte at position 0: 0x3C ("<")
    (jason 1.3.0) lib/jason.ex:92: Jason.decode!/2
    (geoip 0.2.7) lib/geoip/lookup.ex:56: GeoIP.Lookup.parse_response/1
    (geoip 0.2.7) lib/geoip/lookup.ex:23: GeoIP.Lookup.lookup/1
```